### PR TITLE
Please remove spacejamio:underscore.string from atmosphere

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -5,6 +5,8 @@
 //  Some code is borrowed from MooTools and Alexandru Marasteanu.
 //  Version '2.3.3'
 
+console.warn('The spacjamio:underscore.string package has been renamed to practicalmeteor:underscore.string. Please use the new package name instead.');
+
 !function(root, String){
   // Defining helper functions.
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
-  name: "practicalmeteor:underscore.string",
-  summary: "String manipulation extensions for underscore.",
+  name: "spacejamio:underscore.string",
+  summary: "This package has been renamed to practicalmeteor:underscore.string. Please use the new name instead.",
   version: "2.3.3_3",
   git: "https://github.com/practicalmeteor/meteor-underscore.string.git"
 });
@@ -18,7 +18,7 @@ Package.onUse(function (api) {
 
 
 Package.onTest(function(api) {
-  api.use(['practicalmeteor:underscore.string', 'tinytest']);
+  api.use(['spacejamio:underscore.string', 'tinytest']);
 
   api.addFiles('tests/tinytests.js');
 });


### PR DESCRIPTION
There's now an official package for underscore.string: see [underscorestring:underscore.string](https://atmospherejs.com/underscorestring/underscore.string).

Since the authors of Materialize accepted the [Meteor Integration PR](https://github.com/epeli/underscore.string/pull/405) and correctly registered the package on [autopublish.meteor.com](http://autopublish.meteor.com/) we'll have same day updates at every new release of underscore.string.

Please kindly unmigrate this package on atmosphere running the following from your terminal:

```
meteor admin set-unmigrated spacejamio:underscore.string
```

Thank you,
Luca
